### PR TITLE
Exclude code elements from being hidden

### DIFF
--- a/shutup.css
+++ b/shutup.css
@@ -233,10 +233,6 @@ span.postMetaHeaderCommentCount.commentCount,
 
 #feedback,
 
-/* wweek.com */
-
-.Comments,
-
 /* thenextweb.com */
 
 #lf_comments,


### PR DESCRIPTION
Due to good ol' English ambiguity, HTML `<code>` blocks that assign themselves `class="comments"` almost always mean something entirely different from any other tag with the same class. The first commit in this pull request makes an exception for `<code>` elements (unless, I am told, one is using IE8 or lower).

The second commit in this request takes the liberty of removing a superfluous `.Comments` selector midway down the document.
