### PR TITLE
Hide comments on TSN.ca

### DIFF
--- a/shutup.css
+++ b/shutup.css
@@ -334,6 +334,10 @@ span.postMetaHeaderCommentCount.commentCount,
 
 .js_replies,
 
+/* TSN.ca */
+
+#tsnYourCallStory,
+
 /* ...misc... */
 
 .discussionContainer,


### PR DESCRIPTION
Having TSN.ca's "Your Call" comments muted is nearly as essential to my web browsing sanity as muting YouTube. I suspect many other Canadians feel the same.
