### PR TITLE
Update shutup.css

### DIFF
--- a/shutup.css
+++ b/shutup.css
@@ -338,6 +338,9 @@ span.postMetaHeaderCommentCount.commentCount,
 
 #tsnYourCallStory,
 
+/* HS.fi */
+#kommentit,
+
 /* ...misc... */
 
 .discussionContainer,


### PR DESCRIPTION
Added the div id for the comment section for Helsingin Sanomat, the biggest daily newspaper in Finland.
