### PR TITLE
Adding Facebook status-message comments (and the new-comment form).

### DIFF
--- a/shutup.css
+++ b/shutup.css
@@ -341,6 +341,10 @@ span.postMetaHeaderCommentCount.commentCount,
 /* HS.fi */
 #kommentit,
 
+/* Facebook */
+
+div.mainWrapper form,
+
 /* ...misc... */
 
 .discussionContainer,


### PR DESCRIPTION
This may seem a bit silly! But honestly, often when I visit Facebook it's because I wish to see my friends' status messages; all the additional commentary from their random high school friends and their politically passionate uncles and so forth are not always welcome. And so, this is my proposed addition.
