### PR TITLE
Don't hide code comments from highlight.js

### DIFF
--- a/shutup.css
+++ b/shutup.css
@@ -362,6 +362,6 @@ span.postMetaHeaderCommentCount.commentCount,
 }
 
 /* highlight.js */
-:not(code) span.comment {
+code span.comment {
 	display: inline !important;
 }


### PR DESCRIPTION
This change prevents shutup.css from hiding comments in `<code>` blocks as highlighted by [highlight.js](http://softwaremaniacs.org/media/soft/highlight/test.html)
