### PR TITLE
Hide Russia Today comments, the right way.

### DIFF
--- a/shutup.css
+++ b/shutup.css
@@ -346,6 +346,9 @@ span.postMetaHeaderCommentCount.commentCount,
 
 .NB-feed-story-comments,
 
+/* Russia Today */
+.b-comments_page,
+
 /* ...misc... */
 
 #commentlist,
@@ -365,6 +368,3 @@ span.postMetaHeaderCommentCount.commentCount,
 code span.comment {
 	display: inline !important;
 }
-
-/* Russia Today */
-.b-comments_page { display: none !important; }


### PR DESCRIPTION
I [posted this earlier](https://github.com/panicsteve/shutup-css/pull/9), but I hadn't looked carefully at the CSS and had just added my own rule at the bottom. It's now formatted correctly.
