### PR TITLE
Add Hearst's new comment system

### DIFF
--- a/shutup.css
+++ b/shutup.css
@@ -350,6 +350,9 @@ span.postMetaHeaderCommentCount.commentCount,
 /* Russia Today */
 .b-comments_page,
 
+/* Hearst sites */
+.hdn-comments,
+
 /* ...misc... */
 
 #commentlist,


### PR DESCRIPTION
For my own interests, this covers the SF Chronicle, but it should also work on all other Hearst newspapers' sites.
