### PR TITLE
Addition of Cox Media comment region

### DIFF
--- a/shutup.css
+++ b/shutup.css
@@ -357,6 +357,9 @@ span.postMetaHeaderCommentCount.commentCount,
 /* Hearst sites */
 .hdn-comments,
 
+/* Cox Media sites */
+#cmComments,
+
 /* ...misc... */
 
 #commentlist,


### PR DESCRIPTION
Cox Media currently runs 4 major newspapers, 15 TV stations and 86 radio stations, all from the same CMS.  And boy can the comments get racist fast.
