### PR TITLE
Update shutup.css

### DIFF
--- a/shutup.css
+++ b/shutup.css
@@ -360,6 +360,9 @@ span.postMetaHeaderCommentCount.commentCount,
 /* Cox Media sites */
 #cmComments,
 
+/* cleveland.com */
+.rtb-apps-comments-container,
+
 /* ...misc... */
 
 #commentlist,


### PR DESCRIPTION
Added .rtb-apps-comments-container (used by cleveland.com e.g. http://www.cleveland.com/entertainment/index.ssf/2014/01/cleveland_rocks_new_years_eve.html)
