### PR TITLE
Hide nytimes.com comment button

### DIFF
--- a/shutup.css
+++ b/shutup.css
@@ -204,6 +204,7 @@ div#page div#content h2#shoutbox, div#page div#content div#shoutboxContainer,
 /* nytimes.com */
 
 span.postMetaHeaderCommentCount.commentCount,
+button.comments-button,
 
 /* BBC News */
 


### PR DESCRIPTION
Hides this stupid thing in some nytimes.com articles:

![](http://i.imgur.com/1l0W4Ie.png)
