### PR TITLE
added entry to remove comments on Youtube

### DIFF
--- a/shutup.css
+++ b/shutup.css
@@ -35,6 +35,7 @@
 #watch-comment-panel,
 #cm,
 #watch-comments-core,
+#watch-discussion,
 
 /* YouTube (late 2013, G+ integration) */
 


### PR DESCRIPTION
I found it wasn't working on Youtube for me but added in the _slightly_ changed comments id. Being a newb-ish person to web stuff, I tested it by editing via the Style Editor in Firefox.
