### PR TITLE
Hide Kotaku's comment annotations

### DIFF
--- a/shutup.css
+++ b/shutup.css
@@ -416,6 +416,10 @@ div.comments-bar,
 
 .summary-comments,
 
+/* Kotaku */
+.post-content .annotation-footnote-wrapper,
+.post-content .annotateButton,
+
 /* ...misc... */
 
 #commentlist,


### PR DESCRIPTION
They're stuck at the end of every p tag in the article. Added the parent div's class, since .annotateButton seemed like it might hit other non-comment stuff on other sites.