### PR TITLE
Hide comment counts on Vox Media properties

### DIFF
--- a/shutup.css
+++ b/shutup.css
@@ -428,6 +428,7 @@ div.comments-bar,
 /* Curbed */
 .post-comments-module,
 #comments-count,
+.comments-body-container,
 
 /* Polygon */
 .m-hero__comment-count,

--- a/shutup.css
+++ b/shutup.css
@@ -425,6 +425,22 @@ div.comments-bar,
 /* imgur */
 #comments-container,
 
+/* Curbed */
+.post-comments-module,
+#comments-count,
+
+/* Polygon */
+.m-hero__comment-count,
+.comment_count,
+
+/* SB Nation */
+.m-comment-count__bubble,
+.m-stream__node-list__comments,
+
+/* The Verge */
+.p-comment-count,
+.p-entry-header__comments,
+
 /* ...misc... */
 
 #commentlist,


### PR DESCRIPTION
A lot of Vox Media sites will try to attract you by drawing your attention to articles with many comments, when in fact these are probably the articles with comments I most want to avoid.

Also hides the comment form on Curbed, which was not being caught by an existing rule.