### PR TITLE
Hide nytimes.com front page comment links

### DIFF
--- a/shutup.css
+++ b/shutup.css
@@ -208,6 +208,7 @@ div#page div#content h2#shoutbox, div#page div#content div#shoutboxContainer,
 span.postMetaHeaderCommentCount.commentCount,
 button.comments-button,
 a.commentCountLink,
+p.theme-comments,
 
 /* BBC News */
 


### PR DESCRIPTION
The times keeps sneaking in new class names.