### PR TITLE
Adding several Brazilian news websites

### DIFF
--- a/shutup.css
+++ b/shutup.css
@@ -496,6 +496,18 @@ div.comments-bar,
 /* Medium */
 .responsesWrapper,
 
+/* G1 and Globo */
+#boxComentarios,
+
+/* UOL */
+#comentarios,
+
+/* Folha */
+#article-comments,
+
+/* Veja */
+.abril-comentarios-widget,
+
 /* ...misc... */
 
 #commentlist,


### PR DESCRIPTION
Adding the following Brazilian websites:

[g1.com.br](http://g1.globo.com/)
[globo.com](http://www.globo.com/)
[uol.com.br](http://www.uol.com.br/)
[folha.com.br](http://www.folha.uol.com.br/)
[veja.com.br](http://veja.abril.com.br/)