### PR TITLE
Improved Radio-Canada comment hiding. Viafoura seems to be an "Audience Development Platform" (http://viafoura.com/). May block comments on many websites.

### DIFF
--- a/shutup.css
+++ b/shutup.css
@@ -491,7 +491,7 @@ div.comments-bar,
 .box_comment,
 
 /* Radio-Canada */
-#container-pluck,
+.viafoura,
 
 /* Medium */
 .responsesWrapper,


### PR DESCRIPTION
I noticed comments not being hidden on one article and looked further into their commenting system.