### PR TITLE
add HS, IS, TalSa

### DIFF
--- a/shutup.css
+++ b/shutup.css
@@ -527,6 +527,15 @@ div.comments-bar,
 .comments_article,
 #comments-frame,
 
+/* hs.fi */
+#commenting,
+
+/* iltasanomat.fi */
+.is-comments-widget,
+
+/* taloussanomat.fi */
+.xcContainer,
+
 /* ...misc... */
 
 #commentlist,


### PR DESCRIPTION
These are Finnish news sites. The first one (Helsingin Sanomat) is the biggest newspaper in the country, the second (Ilta-Sanomat) is the biggest tabloid, and the third (Taloussanomat) is perhaps the biggest business news site (and generally attracting the worst kind of commentard).