### PR TITLE
Hide dumb little comment buttons on USgamer

### DIFF
--- a/shutup.css
+++ b/shutup.css
@@ -537,6 +537,9 @@ div.comments-bar,
 /* MacRumors mobile site comments link */
 .teaser .teaser_footer > a,
 
+/* USgamer paragraph comment buttons */
+a.button.annotation-count,
+
 /* ...misc... */
 
 #commentlist,


### PR DESCRIPTION
example: http://www.usgamer.net/articles/nintendo-on-switchs-balance-good-enough-graphics-but-easy-to-develop-for