### PR TITLE
Fix blog pages on datatables.net breaking

### DIFF
--- a/shutup.css
+++ b/shutup.css
@@ -560,6 +560,15 @@ a.button.annotation-count,
 
 /* *** Whitelist rules *** */
 
+/*
+ * Some pages use a comments class on the top level element,
+ * blocking the whole page. Weird.
+ */
+html.comments, body.comments,
+html.Comments, body.Comments,
+html#comments, body#comments,
+html#Comments, body#Comments,
+
 /* highlight.js */
 code span.comment,
 


### PR DESCRIPTION
Caused by a comments class on <body>. This may fix other pages too. https://datatables.net/blog/2017-04-07