### PR TITLE
Block fb:comments elements

### DIFF
--- a/shutup.css
+++ b/shutup.css
@@ -279,6 +279,7 @@ p.theme-comments,
 
 .fb-comments,
 .UFIComment,
+fb\:comments,
 
 /* buzzfeed */
 


### PR DESCRIPTION
Affects waitbutwhy, buzzfeed, perhaps others.
Ex: http://waitbutwhy.com/2017/03/elon-musk-post-series.html