### PR TITLE
Hide YouTube Live Chat in beta layout

### DIFF
--- a/shutup.css
+++ b/shutup.css
@@ -548,6 +548,7 @@ a.button.annotation-count,
 
 /* YouTube Live Chat */
 #watch-sidebar-live-chat,
+ytd-live-chat-frame,
 
 /* ...misc... */
 


### PR DESCRIPTION
Enable at https://www.youtube.com/testtube, then view a YouTube live video