### PR TITLE
Add Twitch Selector

### DIFF
--- a/shutup.css
+++ b/shutup.css
@@ -549,6 +549,7 @@ a.button.annotation-count,
 
 /* Twitch Chat */
 #right-column .chat-room,
+.right-column .chat-room__container,
 .channel-page__right-column .chat__container,
 .chat-pane .chat-pane__chat-list,
 


### PR DESCRIPTION
The Twitch selectors were no longer working properly. This adds an additional selector that removes the chat.

Tested on Firefox 57.0.4