### PR TITLE
Fixed tweakers.net

### DIFF
--- a/shutup.css
+++ b/shutup.css
@@ -521,11 +521,9 @@ div.comments-bar,
 /* Dailymotion */
 .pl_video_comment_post_and_comments,
 
-/* 
- * nu.nl and other Dutch websites that use the 'reacties' and 'reactieContainer' class
-*/
-.reacties, /* nu.nl */
-.reactieContainer, /* tweakers.net */
+/* Dutch language websites, including nu.nl and tweakers.net */
+.reacties,
+#reacties,
 
 /* investor.bg and possibly others */
 


### PR DESCRIPTION
Comments weren't blocked on tweakers.net anymore. In the current version of the site 'reactieContainer' is an id instead of a class. Instead of blocking reactieContainer, I opted to block all 'reacties' ids, since that will work on a broad range of sites in Dutch and it's a parent of reactieContainer on tweakers.net.