### PR TITLE
Narrower scope for previous addition

### DIFF
--- a/shutup.css
+++ b/shutup.css
@@ -582,7 +582,7 @@ span#react-root article section + div > ul > li > a.notranslate + span,
 .commentthread_area,
 
 /* HLTV */
-.forum,
+.contentCol .forum,
 
 /* ...misc... */
 


### PR DESCRIPTION
I'm a bit nervous about blocking a `.forum` selector since it may blank out forum pages completely. Adding a `.contentCol` class to try and narrow the scope.