### PR TITLE
Block comments per a user request

### DIFF
--- a/shutup.css
+++ b/shutup.css
@@ -587,6 +587,7 @@ span#react-root article section + div > ul > li > a.notranslate + span,
 /* ...misc... */
 
 #commentlist,
+.comments_area,
 .discussionContainer,
 .commentBoxStyle,
 .pagecomment,


### PR DESCRIPTION
Just adds a `.comments_area` selector, should be harmless.