### PR TITLE
Added nu.nl specific block

### DIFF
--- a/shutup.css
+++ b/shutup.css
@@ -524,6 +524,7 @@ div.comments-bar,
 /* Dutch language websites, including nu.nl and tweakers.net */
 .reacties,
 #reacties,
+.comments-link-wrapper, /* nu.nl */
 
 /* investor.bg and possibly others */
 


### PR DESCRIPTION
Since some time, nu.nl re-enabled comments, without the .reacties class. The added class blocks the link to load comments alltogether