### PR TITLE
Add Seattle Times "View X Comments" button

### DIFF
--- a/shutup.css
+++ b/shutup.css
@@ -152,6 +152,10 @@ div#page div#content h2#shoutbox, div#page div#content div#shoutboxContainer,
 
 #BrowseComments,
 
+/* Seattle Times */
+
+#showcomments,
+
 /* Yahoo News */
 
 .mwpphu-comments,


### PR DESCRIPTION
Seattle Times uses Livefyre, so the comments themselves are already hidden. This PR is to also hide the (now pointless) button to show them.