### PR TITLE
Update Instagram selector to show the first comment

### DIFF
--- a/shutup.css
+++ b/shutup.css
@@ -574,12 +574,8 @@ ytd-live-chat-frame,
 /* Patreon */
 [data-test-tag="comment-row"],
 
-/*
- * Instagram.
- * Professional driver, closed course. Do not attempt.
- */
-span#react-root main article section + div > ul,
-html.client-root [role="dialog"] article section + div > ul,
+/* Instagram */
+li.gElp9:not(:first-child),
 
 /* Pixiv */
 #js-mount-point-comment-module,


### PR DESCRIPTION
This is almost always posted by the account holder as a description of the image.
ex: https://www.instagram.com/p/BupJ__WjA9C/

Also, based on what I've learned about React over the past year or so, Instagram appears to use Styled Components. The `.gElp9` classname is a hash of the styles being applied. This classname has been stable since at least September, so I feel confident using it over the (rad) compound selector we were using previously.