### PR TITLE
Unhide MediaWiki edit summary previews

### DIFF
--- a/shutup.css
+++ b/shutup.css
@@ -667,9 +667,10 @@ html#Comments, body#Comments,
 /* highlight.js */
 code span.comment,
 
-/* Wikipedia revision history */
+/* MediaWiki edit summaries (Wikipedia, etc.) */
 #pagehistory .comment,
-table.diff .comment
+table.diff .comment,
+.mw-summary-preview .comment
 
 {
 	display: initial !important;


### PR DESCRIPTION
Just like on revision history and comparison pages, MediaWiki uses a `comment` class on edit summary previews.

<img width="327" alt="Screen Shot 2019-09-04 at 1 03 01 PM" src="https://user-images.githubusercontent.com/281175/64275901-a2d9f780-cf14-11e9-8328-deb6ddc31b35.png">
