### PR TITLE
Whitelist GitHub PR comments

### DIFF
--- a/shutup.css
+++ b/shutup.css
@@ -675,3 +675,10 @@ table.diff .comment,
 {
 	display: initial !important;
 }
+
+/* GitHub – Pull Request comments */
+.repository-content .comment
+
+{
+    display: block !important;
+}


### PR DESCRIPTION
This PR prevents Pull Requests comments, message previews etc... to be hidden.

`display: block !important;` is used instead of `display: initial !important;` as the last one does not put back the initial render properly.