### PR TITLE
Block comments on Thrillist

### DIFF
--- a/shutup.css
+++ b/shutup.css
@@ -627,6 +627,9 @@ body[ng-app="pdaily"] a.discussions,
 #comm_show_more,
 a[name="komentarze"],
 
+/* Thrillist */
+.comments__spotim,
+
 /* ...misc and generic... */
 
 .comments-list,


### PR DESCRIPTION
ex: https://www.thrillist.com/entertainment/nation/best-fantasy-book-series-sci-fi-science-fiction