### PR TITLE
Remove en-dash character

### DIFF
--- a/shutup.css
+++ b/shutup.css
@@ -689,7 +689,7 @@ table.diff .comment,
 	display: initial !important;
 }
 
-/* GitHub – Pull Request comments */
+/* GitHub - Pull Request comments */
 .repository-content .comment
 
 {


### PR DESCRIPTION
This character broke `window.btoa()` in the Chrome and Firefox versions of Shut Up.