### PR TITLE
Fix comment blocking on Daum News

### DIFF
--- a/shutup.css
+++ b/shutup.css
@@ -435,7 +435,7 @@ div.comments-bar,
 #cbox_module,
 
 /* DAUM News */
-.cmt_news,
+.cmt_view,
 
 /* Radio-Canada */
 .viafoura,


### PR DESCRIPTION
Due to Daum's code change, shutup.css is not working on Daum News pages.

Here's a sample of their changed code from the Firefox web inspector.
<img width="1319" alt="스크린샷 2020-02-03 오후 9 00 47" src="https://user-images.githubusercontent.com/1343747/73651994-0d13e580-46c9-11ea-8272-f1b911f4ac04.png">

ex: https://news.v.daum.net/v/20200203204213420