### PR TITLE
Remove comments button and comment count for BBC news

### DIFF
--- a/shutup.css
+++ b/shutup.css
@@ -184,7 +184,9 @@ a.commentCountLink,
 p.theme-comments,
 
 /* BBC News */
+.comments-button,
 .dna-comment,
+.nw-c-comment,
 
 /* ZDNet */
 .view-6,


### PR DESCRIPTION
- Adding `.nw-c-comment` removes the "comp comment button" comment counter elements that appear on landing pages (like https://www.bbc.co.uk/news/uk) next to articles
- Adding `.comments-button` removes the "View Comments" button that appears at the bottom of articles, i.e. https://www.bbc.co.uk/news/uk-northern-ireland-53130995 