### PR TITLE
add teltarif.de

### DIFF
--- a/shutup.css
+++ b/shutup.css
@@ -678,6 +678,9 @@ div.detail-characters-list ~ div.borderDark,
 .content form ~ a#ci ~ div[id^=c8],
 .content form ~ a#ci ~ div[id^=c9],
 
+/* teltarif.de */
+#LxComments,
+
 /* ...misc and generic... */
 
 [id*=commentaires i],


### PR DESCRIPTION
Hi, 
teltarif.de is a german blog/news site around mobile plan providers , ISPs and related topics.