### PR TITLE
Allow comments in <pre> blocks that don't contain <code> elements

### DIFF
--- a/shutup.css
+++ b/shutup.css
@@ -723,8 +723,9 @@ html.Comments, body.Comments,
 html#comments, body#comments,
 html#Comments, body#Comments,
 
-/* highlight.js */
+/* highlight.js and Prism */
 code span.comment,
+pre span.comment,
 
 /* MediaWiki edit summaries (Wikipedia, etc.) */
 #pagehistory .comment,


### PR DESCRIPTION
This accounts for some (not semantically correct) uses of syntax highlighters. Examples:

- https://www.npmjs.com/package/moment-locales-webpack-plugin (using highlight.js)
- https://kentcdodds.com/blog/javascript-to-know-for-react (using Prism)
