### PR TITLE
Refactor shutup.css with generic selectors

### DIFF
--- a/shutup.css
+++ b/shutup.css
@@ -34,11 +34,8 @@
  */
 
 /* YouTube */
-#watch-comment-panel,
 #cm,
-#watch-comments-core,
 #watch-discussion,
-#comments-test-iframe,
 ytm-comment-section-renderer,
 
 /* Disqus */
@@ -47,17 +44,6 @@ iframe[src*="disqus.com/embed"],
 body [id*=disqus i],
 body [class*=disqus i],
 #dsq-content,
-
-/*
- * Digg and other sites that use "comments" divs
- * (Make an exception for <code> elements, whose "comments" are
- * a different animal)
-*/
-.comments:not(code),
-.Comments:not(code),
-#comments:not(code),
-#Comments:not(code),
-#comments_container,
 
 /* Ain't It Cool News */
 .block-talkback_story,
@@ -68,142 +54,28 @@ body [class*=disqus i],
 /* MacUpdate */
 .revcontent,
 
-/* WordPress default Kubrick theme and descendents */
-.commentlist,
-
-/* Slashdot */
-#commentlisting,
-
-/* CBC News */
-#socialcomments,
-#commentwrapper,
-
-/* C|Net News.com */
-.commentwrapper,
-
-/* Reddit */
-.commentarea,
-
-/* Designer News */
-#story-comments,
-
-/* OregonLive and generic "comment" class */
-.comment,
-
-/* KATU */
-#commentform,
-
-/* Washington Post and other sites that use "commentText" divs */
-.commentText,
-
-/* Gannett newspapers and other sites that use Pluck */
-div#pluckcomments,
-
 /* Last.fm shoutbox */
 div#page div#content h2#shoutbox,
 div#page div#content div#shoutboxContainer,
 div#shoutbox section.shoutbox,
 
-/* The Globe and Mail */
-#latest-comments,
-
-/* EW */
-.commentHolder,
-
-/* Boxee */
-.comment-container,
-#comment-container,
-
-/* MLB */
-#comment_container,
-
-/* CNN */
-#commentblob,
-#cnnComments,
-
-/* The Stranger */
-#BrowseComments, .fa-comment, .comment-count,
-
-/* Seattle Times */
-#showcomments,
-
-/* Crosscut */
-.comments__btn,
-
-/* Yahoo News */
-.mwpphu-comments,
-.ugccmt-comments,
-
-/* Coding Horror */
-.comments-body,
-
-/* seen on Reuters */
-.articleComments,
-
 /* nationalpost.com (Pluck) */
 .pluck-comm,
 
-/* KATU */
-.page-comments,
-
 /* DeviantArt */
-#gmi-CCommentMaster,
 div[data-hook=comments_thread],
-
-/* Some blogs */
-.comments-container,
-
-/* Oprah */
-#media_comments,
 
 /* 9to5mac */
 #idc-container-parent,
 
 /* Livefyre */
-#livefyre_comment_stream,
 #livefyre-body,
 #livefyre,
 .fyre,
 
-/* PC World */
-#articleComments,
-
-/* Slate */
-.js-CommentsArea,
-
-/* NYTimes Blogs */
-#readerComments,
-.readerComments,
-#commentsContainer,
-.commentsContainer,
-.commentsModule,
-
-/* nytimes.com */
-span.postMetaHeaderCommentCount.commentCount,
-button.comments-button,
-a.commentCountLink,
-p.theme-comments,
-
-/* BBC News */
-.comments-button,
-.dna-comment,
-.nw-c-comment,
-
 /* ZDNet */
 .view-6,
 .space-_5,
-
-/* Gamasutra */
-.all_comments,
-
-/* dvice.com */
-#display_comments,
-
-/* hp.com */
-.article-comments,
-
-/* unionleader.com */
-#commentscontainer,
 
 /* ifc.com */
 .echo-stream-container,
@@ -211,30 +83,10 @@ p.theme-comments,
 /* creativereview.co.uk */
 #feedback,
 
-/* thenextweb.com */
-#lf_comments,
-#lf_twitter_comments,
-#lf_facebook_comments,
-#lf_comment_stream,
-
-/* MacWorld */
-#commentList,
-
-/* ft.com */
-#inferno-comments,
-
 /* tidbits.com */
 .cb_block,
 
-/* dilbert.com */
-.CMT_CommentList,
-
-/* Cracked */
-#comments_section,
-
 /* Facebook feedback */
-.fb-comments,
-.UFIComment,
 fb\:comments,
 div[data-testid^=UFI2CommentsList],
 /* new facebook beta look */
@@ -244,47 +96,30 @@ div[data-testid^=UFI2CommentsList],
 /* buzzfeed */
 #responses,
 #facebook_responses,
-#facebook_conversations,
-#fb_comments_wrapper,
-#fb_comments_control,
-.fb-comments-area,
 #respond,
 #badge_voting,
 
 /* spiegel.de */
-.spCommentsBoxBody,
 #spArticleFunctionForum,
 body[data-guj-zone~="forum"] #postList,
-#js-article-comments-box-form,
 .spInteractionMarks,
-.clearfix.article-comments-box.module-box,
 
 /* handelsblatt.de */
 a[href*="detail_tab_comments"],
-.vhb-comments-container,
 
 /* handelsblatt.com */
 .hcf-article.hcf-content.hcf-article-type2,
 
-/* auto-motor-und-sport.de */
-.kommentare_uebersicht,
-
 /* corriere.it */
 #body_dlt,
-#comment_box_article,
 
 /* repubblica.it */
 #ugc-container,
-#gs-social-comments,
-.gig-comments-container,
 
 /* faz.net */
 .ArtikelKommentieren,
 .tsr-Base_ContentMetaItem-social-feedback,
 #lesermeinungen,
-
-/* Giant Bomb avatars */
-.comment-avatar-wrap,
 
 /* hlntv.com */
 .fbFeedbackContent,
@@ -292,48 +127,17 @@ a[href*="detail_tab_comments"],
 /* mirror.co.uk */
 .pluck-wrap,
 
-/* TwitPic */
-#media-comments,
-
 /* Guardian */
 #d2-root,
 
-/* E! Online */
-.thyme-comment-list,
-
-/* SoundCloud */
-.commentsList,
-.commentsList__item .commentItem,
-.commentPopover,
-
-/* Penny Arcade report */
-#vanilla-comments,
-
 /* Mother Nature Network */
 .replies-wrapper > .replies,
-.view-comment-list,
 
 /* New Jalopnik (and Gawker?) */
 .js_replies,
-.js_comments-iframe,
 
 /* TSN.ca */
 #tsnYourCallStory,
-
-/* NewsBlur */
-.NB-feed-story-comments,
-
-/* Russia Today */
-.b-comments_page,
-
-/* Hearst sites */
-.hdn-comments,
-
-/* Cox Media sites */
-#cmComments,
-
-/* cleveland.com */
-.rtb-apps-comments-container,
 
 /* derstandard.at */
 .communityCanvas,
@@ -341,60 +145,15 @@ a[href*="detail_tab_comments"],
 /* derstandard.de */
 section#story-community.story-community,
 
-/* presse.at */
-#commentbox,
-#newcommentform,
-
 /* ka-news.de */
 #QuickRegCon,
-
-/* tagesschau.de */
-.inpagecomments,
-.modCon.modConComments,
 
 /* taz.de */
 .full.community.page.last.even,
 
-/* fr-online.de */
-#commentsRoot,
-.Comment,
-
-/* huffingtonpost.de */
-#conversations-huffpost-web-main,
-
-/* wiwo.de */
-.hcf-detail.hcf-comments-container,
-
-/* arstechnica.com */
-
-section#promoted-comments,
-aside.comments-hotness,
-a.comment-count,
-div.comments-bar,
-
-/* trakt.tv */
-
-.summary-comments,
-
 /* Kotaku */
 .post-content .annotation-footnote-wrapper,
 .post-content .annotateButton,
-
-/* imgur */
-#comments-container,
-
-/* Curbed */
-.post-comments-module,
-#comments-count,
-.comments-body-container,
-
-/* Polygon */
-.m-hero__comment-count,
-.comment_count,
-
-/* SB Nation */
-.m-comment-count__bubble,
-.m-stream__node-list__comments,
 
 /* The Verge */
 [data-ui=comment],
@@ -405,29 +164,8 @@ div.comments-bar,
 /* lefigaro.fr */
 #reagir,
 
-/* huffingtonpost.fr */
-#conversations-huffpost-web,
-
-/* Civil Comments */
-#civil-comments,
-
-/* 9gag */
-.post-comment,
-
 /* Engadget (Confab) */
 .confab,
-
-/* Gamasutra */
-#dynamiccomments,
-
-/* GameSpot */
-.comments-block,
-
-/* GiantBomb */
-.js-comments-block,
-
-/* LINE Webtoon */
-.comment_area,
 
 /* NAVER News */
 #cbox_module,
@@ -448,35 +186,15 @@ div.comments-bar,
 /* UOL */
 #comentarios,
 
-/* Folha */
-#article-comments,
-
 /* Veja */
 .abril-comentarios-widget,
 
 /* VK */
 .replies_wrap > div:first-child,
-#pv_comments.wall_module,
-#mv_comments.wall_module,
-
-/* Dailymotion */
-.pl_video_comment_post_and_comments,
 
 /* Dutch language websites, including nu.nl and tweakers.net */
 .reacties,
 #reacties,
-.comments-link-wrapper, /* nu.nl */
-
-/* investor.bg and possibly others */
-.comments_article,
-#comments-frame,
-
-/* hs.fi */
-#commenting,
-
-/* iltasanomat.fi */
-.is-comments-widget,
-#comments-list,
 
 /* MacRumors mobile site comments link */
 .teaser .teaser_footer > a,
@@ -495,9 +213,6 @@ div[data-a-target="right-column-chat-bar"],
 #watch-sidebar-live-chat,
 ytd-live-chat-frame,
 
-/* GoComics */
-.js-comments-thread-container,
-
 /* Patreon */
 [data-test-tag="comment-row"],
 [data-tag="comment-row"],
@@ -509,8 +224,6 @@ article._8Rm4L a.r8ZrO, /* Feed, show comments link */
 
 /* Pixiv */
 div#root section.dBUetj,
-#js-mount-point-comment-module,
-.comment-list,
 
 /* Pixiv Fanbox */
 div#root div.jUvQSR,
@@ -518,21 +231,8 @@ div#root div.jUvQSR,
 /* Yahoo! News floating comment dingus */
 #YDC-MainCanvas .canvas-share-buttons > div:last-child,
 
-/* Refinery29 */
-.sppre_conversation-view,
-
-/* Steam Community */
-.commentthread_area,
-
 /* HLTV */
 .contentCol .forum,
-
-/* Quora */
-.threaded_comments,
-
-/* Times of India */
-.topcomment,
-.bottom-comments,
 
 /* Sydney Morning Herald (and possibly others) */
 iframe[src*="ffx.io/api/comments"],
@@ -545,54 +245,24 @@ iframe[src*="ffx.io/api/comments"],
 .apester-fill-content,
 
 /* heise.de */
-.comment-button,
-.media-icon--comments,
-.a-article-meta__icon--comments,
-#comments_container,
-.kommentare_lesen_link,
 .forenbeitraege_show,
 a[name="meldung.newsticker.header.kommentarelesen"],
-.kommentare-info,
 
 /* mactechnews.de */
 span[title*="#comments"],
-.MtnCommentScroll,
-#ContentPlaceHolder1_FieldsetCommentEditor,
-#ContentPlaceHolder1_ButtonCommentPublish,
 
 /* maclife.de */
 .shares .count,
-#maclife #comments,
 
 /* apfelpage.de */
 a[href*="#respond"],
 a[href*="#comments"],
 
-/* computerbase.de */
-.article__comments-link,
-
 /* giga.de */
-#comments+#weiterethemen,
-.comment-section,
-
-/* mdr.de */
-.modComments,
-
-/* tagesspiegel.de */
-#kommentare,
-#hcf-comment-wrapper.hcf-comments,
-#commentInput.hcf-comments-input,
-.hcf-comments,
-
-/* haz.de */
-.pdb-article-comments,
+#comments + #weiterethemen,
 
 /* welt.de */
-.o-teaser__comment-count,
 div[data-external-component="User.Article.Likes"],
-
-/* focus.de */
-#article #commentForm,
 
 /* t-online.de */
 #talk_community,
@@ -603,35 +273,14 @@ div[data-external-component="User.Article.Likes"],
 /* netzwelt.de */
 a[href*="#kommentare"],
 
-/* krautreporter.de */
-#show-comments-container,
-.article-comments,
-
 /* perspective-daily.de */
 body[ng-app="pdaily"] a.discussions,
 .discussion_body,
 .tabs_container li:last-child,
 
-/* tz.de */
-.id-Comment,
-
-/* piqd.de */
-.pq-comment-form-wrap,
-.rspec-comments-total,
-
-/* PressTV.com */
-#hypercomments_widget,
-
-/* Thehindu.com */
-#vuukle-comments,
-
 /* tekstowo.pl */
-#comments_content,
 #comm_show_more,
 a[name="komentarze"],
-
-/* Thrillist */
-.comments__spotim,
 
 /* Comments.app */
 iframe[src*="comments.app"],
@@ -643,18 +292,14 @@ iframe[src*="comments.ign.com"],
 [class^=main] div[class^=content] div[data-test^=thread],
 
 /* Le Figaro */
-#commentsTitle, #commentsTitle + ul, #commentsTitle + ul + span,
+#commentsTitle + ul, #commentsTitle + ul + span,
 
 /* Le Monde */
 .article__reactions,
 
-/* Slickdeals */
-#commentsBox,
-
 /* Tweetdeck */
 div.js-replies-to.replies-after article + article,
 div.js-tweet-replies article,
-div.js-conversation-show-more.conversation-more,
 
 /* Newgrounds */
 div.pod-body.review,
@@ -664,12 +309,6 @@ div.pod-body.review,
 
 /* MyAnimeList */
 div.detail-characters-list ~ div.borderDark,
-
-/* teltarif.de */
-#LxComments,
-
-/* gazeta.pl */
-.commentsApp,
 
 /* Adult */
 .content form ~ a#ci ~ div[id^=c0],
@@ -684,48 +323,34 @@ div.detail-characters-list ~ div.borderDark,
 .content form ~ a#ci ~ div[id^=c9],
 #cdiv.gm,
 
-/* ...misc and generic... */
-
-body [id*=commentaires i],
-body [class*=commentaires i],
-.comments-list,
-#blogComments,
-#comments_pane,
-#commentcontainer,
-#commentsDiv,
-#comment_entries,
-#comment_form,
-#commentlist,
-#user-comments,
-.comments_area,
-.comments-area,
+/* Misc. */
 .discussionContainer,
-.commentBoxStyle,
-.pagecomment,
-.pagecommentheader,
 .com_text,
-.commenttxt,
-.post-comments,
-.post-comment-list,
-.user_comment,
-.widget-comments,
-.commentBox,
-#cmtWrapper
+#cmtWrapper,
+
+/* *************** */
+/* *** Generic *** */
+/* *************** */
+
+/* English */
+body [id*=comment i]:not(code),
+body [id*=conversation i],
+body [class*=comment i]:not(code),
+body [class*=conversation i],
+/* French */
+body [id*=commentaire i]:not(code),
+body [class*=commentaire i]:not(code),
+/* German */
+body [id*=kommentare i]:not(code),
+body [class*=kommentare i]:not(code)
 {
 	display: none !important;
 }
 
 
-/* *** Allowlist rules *** */
-
-/*
- * Some pages use a comments class on the top level element,
- * blocking the whole page. Weird.
- */
-html.comments, body.comments,
-html.Comments, body.Comments,
-html#comments, body#comments,
-html#Comments, body#Comments,
+/* ****************** */
+/* *** Exceptions *** */
+/* ****************** */
 
 /* City Observatory's "City Commentary" posts */
 body.post-template-default.category-commentary
@@ -740,14 +365,12 @@ pre span.comment,
 #pagehistory .comment,
 table.diff .comment,
 .mw-summary-preview .comment
-
 {
 	display: initial !important;
 }
 
 /* GitHub - Pull Request comments */
 .repository-content .comment
-
 {
 	display: block !important;
 }

--- a/shutup.css
+++ b/shutup.css
@@ -45,14 +45,9 @@ body [id*=disqus i],
 body [class*=disqus i],
 #dsq-content,
 
-/* Ain't It Cool News */
-.block-talkback_story,
-
-/* VersionTracker */
-#prodReviews,
-
-/* MacUpdate */
-.revcontent,
+/* spot.im/OpenWeb */
+body [id*=spotim i],
+body [class*=spotim i],
 
 /* Last.fm shoutbox */
 div#page div#content h2#shoutbox,
@@ -82,9 +77,6 @@ div[data-hook=comments_thread],
 
 /* creativereview.co.uk */
 #feedback,
-
-/* tidbits.com */
-.cb_block,
 
 /* Facebook feedback */
 fb\:comments,
@@ -121,23 +113,14 @@ a[href*="detail_tab_comments"],
 .tsr-Base_ContentMetaItem-social-feedback,
 #lesermeinungen,
 
-/* hlntv.com */
-.fbFeedbackContent,
-
 /* mirror.co.uk */
 .pluck-wrap,
 
-/* Guardian */
-#d2-root,
-
-/* Mother Nature Network */
+/* Treehugger */
 .replies-wrapper > .replies,
 
 /* New Jalopnik (and Gawker?) */
 .js_replies,
-
-/* TSN.ca */
-#tsnYourCallStory,
 
 /* derstandard.at */
 .communityCanvas,
@@ -164,43 +147,20 @@ section#story-community.story-community,
 /* lefigaro.fr */
 #reagir,
 
-/* Engadget (Confab) */
-.confab,
-
 /* NAVER News */
 #cbox_module,
 
 /* DAUM News */
 .cmt_view,
 
-/* Radio-Canada */
-.viafoura,
-
 /* Medium */
-.responsesWrapper,
-.responsesStreamWrapper,
-
-/* G1 and Globo */
-#boxComentarios,
-
-/* UOL */
-#comentarios,
-
-/* Veja */
-.abril-comentarios-widget,
+div#root > div.a.b.c article ~ div div + div + button,
 
 /* VK */
 .replies_wrap > div:first-child,
 
-/* Dutch language websites, including nu.nl and tweakers.net */
-.reacties,
-#reacties,
-
 /* MacRumors mobile site comments link */
 .teaser .teaser_footer > a,
-
-/* USgamer paragraph comment buttons */
-a.button.annotation-count,
 
 /* Twitch Chat */
 #right-column .chat-room,
@@ -233,6 +193,9 @@ div#root div.jUvQSR,
 
 /* HLTV */
 .contentCol .forum,
+
+/* Times of India */
+.cmtwrapper,
 
 /* Sydney Morning Herald (and possibly others) */
 iframe[src*="ffx.io/api/comments"],
@@ -342,7 +305,13 @@ body [id*=commentaire i]:not(code),
 body [class*=commentaire i]:not(code),
 /* German */
 body [id*=kommentare i]:not(code),
-body [class*=kommentare i]:not(code)
+body [class*=kommentare i]:not(code),
+/* Spanish, Portuguese */
+body [id*=comentario i]:not(code),
+body [class*=comentario i]:not(code),
+/* Dutch */
+body [id*=reacties i],
+body [class*=reacties i]
 {
 	display: none !important;
 }
@@ -368,6 +337,9 @@ table.diff .comment,
 {
 	display: initial !important;
 }
+
+/* VK */
+#page_wall_posts .closed_comments,
 
 /* GitHub - Pull Request comments */
 .repository-content .comment


### PR DESCRIPTION
Following [my proposed change from a few days ago](https://github.com/panicsteve/shutup-css/pull/132#issuecomment-702442777), we now have [generic selectors](https://github.com/panicsteve/shutup-css/compare/master...RickyRomero:main#diff-d19b9ef2a945fbb79cb72bbfee22ba7fR294-R314) for English, French, German, Spanish, Portuguese, and Dutch sites.

This change improves comment blocking quite a bit. For example, these sites were broken, but aren't anymore:

- Washington Post
- Coding Horror
- National Post
- AppleInsider
- Cracked.com
- spot.im (generic comments service like Disqus)
- imgur
- Steam Community

I tested roughly 70% of the sites listed in the CSS and found this change to be a pretty big improvement overall. In many cases, we now block additional UI related to showing comments that we didn't before. The only site that broke as a result of this change was VK, which I easily fixed with another exception rule.

I also cleaned up a few sites which had either changed the classnames they use, or were defunct, or whatever.