### PR TITLE
Quick fixes for Mastodon and The Guardian

### DIFF
--- a/shutup.css
+++ b/shutup.css
@@ -82,8 +82,8 @@ div[data-hook=comments_thread],
 fb\:comments,
 div[data-testid^=UFI2CommentsList],
 /* new facebook beta look */
-[aria-label^="Comment"],
-[aria-label^="Reply"],
+[data-pagelet*="FeedUnit"] [aria-label^="Comment"],
+[data-pagelet*="FeedUnit"] [aria-label^="Reply"],
 
 /* buzzfeed */
 #responses,

--- a/shutup.css
+++ b/shutup.css
@@ -330,6 +330,9 @@ body.post-template-default.category-commentary
 code span.comment,
 pre span.comment,
 
+/* The Guardian */
+[class*=tonal][class*=comment],
+
 /* MediaWiki edit summaries (Wikipedia, etc.) */
 #pagehistory .comment,
 table.diff .comment,


### PR DESCRIPTION
Reply buttons are hidden on Mastodon due to a rule we set up for Facebook.
Also, my last update broke "comment" "tone" pages on The Guardian... https://www.theguardian.com/tone/comment