### PR TITLE
Remove #cm selector to fix CodeMirror

### DIFF
--- a/shutup.css
+++ b/shutup.css
@@ -34,7 +34,6 @@
  */
 
 /* YouTube */
-#cm,
 #watch-discussion,
 ytm-comment-section-renderer,
 


### PR DESCRIPTION
The #cm selector too broad. There are many sites which use CodeMirror, where some functionality (writing code comments) is broken because of this.

Code comments are NOT social comments.

Some sites where the functionality is broken because of this selector:

- codemirror.net
- leetcode.com
- codepen.io
- jsfiddle.com
- pramp.com
- glitch.com

In order to test this, just enter any of those sites with Shut Up enabled, and try to write any comment (using `// test` for instance). You will notice the comments are hidden.