### PR TITLE
Added Trójmiasto.pl

### DIFF
--- a/shutup.css
+++ b/shutup.css
@@ -672,6 +672,9 @@ div.detail-characters-list ~ div.borderDark,
 /* gazeta.pl */
 .commentsApp,
 
+/* Trójmiasto.pl */
+.Opinions,
+
 /* AppleInsider */
 .comment-section-head,
 .comment-section-head ~ .forum-comment,


### PR DESCRIPTION
I added a local website from Gdańsk metropolitan area called Trójmiasto.pl, it is well-known among locals to have the stupidest comments in the Baltic Sea area, so the comment blocking is much needed. 