### PR TITLE
Block Coral comments

### DIFF
--- a/shutup.css
+++ b/shutup.css
@@ -54,6 +54,10 @@ body [id*=spot-im i],
 body [class*=spotim i],
 body [class*=spot-im i],
 
+/* Coral */
+div[id="coral_talk_stream"],    /* v4 */
+div[id="coral_thread"],         /* v5 */
+
 /*
  * Digg and other sites that use "comments" divs
  * (Make an exception for <code> elements, whose "comments" are


### PR DESCRIPTION
- v4 docs: https://docs.coralproject.net/coral/integrating/cms-integration/
- v4 example: https://www.latimes.com/obituaries/story/2021-01-08/dodgers-legendary-manager-tom-lasorda-dies-at-age-93-heart-attack (This example isn't great because the Coral embed is descended from an element that is already hidden by other rules, but it's the only v4 example I have at hand.)
- v5 docs: https://docs.coralproject.net/coral/v5/integrating/cms/
- v5 example: https://defector.com/james-harden-is-a-net-no-matter-how-kyrie-irving-fits-the-plan/