### PR TITLE
Fix comment blocking on Le Figaro

### DIFF
--- a/shutup.css
+++ b/shutup.css
@@ -406,7 +406,7 @@ div.comments-bar,
 .liste_reactions,
 
 /* lefigaro.fr */
-#reagir,
+.fig-comments,
 
 /* huffingtonpost.fr */
 #conversations-huffpost-web,


### PR DESCRIPTION
ex: https://www.lefigaro.fr/actualite-france/covid-19-la-grande-lassitude-des-francais-face-aux-restrictions-20210222