### PR TITLE
Hide entire Patreon comment section

### DIFF
--- a/shutup.css
+++ b/shutup.css
@@ -572,7 +572,7 @@ nav[aria-label="Hopin main menu"] ~ div.test-id-panel#side-panel,
 
 /* Patreon */
 [data-test-tag="comment-row"],
-[data-tag="comment-row"],
+[data-tag="post-details"] ~ :last-child,
 
 /* Instagram */
 ul.Mr508, /* Detail page, all comments except OP */


### PR DESCRIPTION
The current selector hides comments individually but leaves detritus like "Load" links, comment counts, and the submission box:

<img width="699" alt="Screen Shot 2021-11-08 at 2 35 46 PM" src="https://user-images.githubusercontent.com/281175/140809639-ced6f23b-bf17-4968-a789-01c54570f75e.png">

Avoid this by hiding the ancestor container:

<img width="699" alt="Screen Shot 2021-11-08 at 2 36 08 PM" src="https://user-images.githubusercontent.com/281175/140809698-9d503889-4fe4-4949-8e63-86eaaac6aeb7.png">

ex: https://www.patreon.com/posts/patreon-preview-31739550