### PR TITLE
Hide comments on Patreon/chat on Twitch; remove Stylish recommendation

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ These extensions by [Ricky Romero][site-ricky] automatically update themselves w
 
 Shut Up for Safari on macOS requires macOS Sierra or later.
 
-If you don't want a separate extension, you can instead use the [Stylish][stylish-plugin] plug-in, in combination with the raw shutup.css stylesheet (detailed below).
+If you don't want a separate extension, you can instead use the [Stylus][stylus-plugin] plug-in, in combination with the raw shutup.css stylesheet (detailed below).
 
 ### Installation on Opera
 
@@ -119,4 +119,4 @@ You can contact me at [stevenf@panic.com][email-steven], or on Twitter as [@stev
 [twitter-steven]: https://twitter.com/stevenf/  (Steven Frank's Twitter profile)
 
 [content-blocker-plus]: https://apps.apple.com/app/id1040960141  (Content Blocker+)
-[stylish-plugin]: https://userstyles.org/  (Stylish Plugin)
+[stylus-plugin]: https://add0n.com/stylus.html  (Stylus Plugin)

--- a/shutup.css
+++ b/shutup.css
@@ -559,6 +559,7 @@ a.button.annotation-count,
 .channel-page__right-column .chat__container,
 .chat-pane .chat-pane__chat-list,
 div[data-a-target="right-column-chat-bar"],
+.stream-chat,
 
 /* YouTube Live Chat */
 #watch-sidebar-live-chat,

--- a/shutup.css
+++ b/shutup.css
@@ -38,7 +38,6 @@
 #watch-comments-core,
 #watch-discussion,
 #comments-test-iframe,
-#cm,
 ytm-comment-section-renderer,
 ytm-comments-entry-point-header-renderer,
 ytm-engagement-panel,
@@ -299,6 +298,14 @@ html#facebook [aria-label^="\41E \442 \432 \435 \442 "],                      /*
 .UFIComment,
 fb\:comments,
 div[data-testid^=UFI2CommentsList],
+
+/* LinkedIn */
+.comments-comment-item,
+.comments-comments-list,
+.comments-comments-list__comment-item,
+.feed-shared-update-v2__comments-container,
+.social-details-first-prompt-block,
+.social-details-social-counts__comments,
 
 /* buzzfeed */
 #responses,


### PR DESCRIPTION
This PR incorporates the changes from https://github.com/panicsteve/shutup-css/pull/162.

I replaced Stylish in the recommended installation methods with [Stylus](https://add0n.com/stylus.html) because of [privacy concerns](https://en.wikipedia.org/wiki/Stylish#Privacy_issues).
