### PR TITLE
Hide comment containers on Stack Exchange sites

### DIFF
--- a/shutup.css
+++ b/shutup.css
@@ -782,6 +782,10 @@ table.ttxt2 td.ctxt,
 /* 1plus1.video */
 ._opo_-playlist-comments,
 
+/* Stack Exchange sites (e.g., Stack Overflow) */
+[itemprop="commentCount"],
+.js-post-comments-component,
+
 /* Various shady sites */
 .content form ~ a#ci ~ div[id^=c0],
 .content form ~ a#ci ~ div[id^=c1],


### PR DESCRIPTION
The default selectors hide individual comments but leave detritus like the "Add a comment" and "Show _x_ more comments" links.

![old](https://user-images.githubusercontent.com/281175/141691536-5d7739be-ffab-46e0-bd1e-9b1a97ba5535.png)

Avoid this by hiding the ancestor container.

![new](https://user-images.githubusercontent.com/281175/141691542-0aa83dad-c143-455c-8f4a-4e50589480d5.png)

(ex: https://stackoverflow.com/questions/3231804/in-bash-how-to-add-are-you-sure-y-n-to-any-command-or-alias)