### PR TITLE
Block preview comment on YouTube desktop

### DIFF
--- a/shutup.css
+++ b/shutup.css
@@ -44,6 +44,7 @@ ytm-engagement-panel,
 ytd-comments,
 ytd-comment-thread-renderer,
 ytd-comment-renderer,
+ytd-comments-entry-point-header-renderer,
 
 /* Disqus */
 a[data-disqus-identifier],


### PR DESCRIPTION
This block exists for the mobile version, but the desktop version uses a slightly different element name.