### PR TITLE
Update nytimes ids

### DIFF
--- a/shutup.css
+++ b/shutup.css
@@ -204,6 +204,10 @@ a.commentCountLink,
 p.theme-comments,
 #comments-speech-bubble-top,
 #comments-speech-bubble-bottom,
+#comments-speech-bubble-header,
+#comments-speech-bubble-footer,
+#comments-speech-bubble-bigBottom,
+#comments-speech-bubble-inStoryMasthead,
 
 /* Wall Street Journal */
 #comments_sector,


### PR DESCRIPTION
Adds a few new IDs nytimes.com seems to be using now.