### PR TITLE
Remove comment counts for formel1.de and golem.de

### DIFF
--- a/shutup.css
+++ b/shutup.css
@@ -800,6 +800,13 @@ table.ttxt2 td.ctxt,
 /* theage.com.au */
 [data-testid="comments-cta"],
 
+/* formel1.de */
+.fa-comments,
+.btn-comments,
+
+/* golem.de */
+.icon-comments,
+
 /* Various shady sites */
 .content form ~ a#ci ~ div[id^=c0],
 .content form ~ a#ci ~ div[id^=c1],


### PR DESCRIPTION
As per title, this removes the comment counts on the start page of both sites. Also removes the comment count inside the article for formel1.de

ex: https://www.golem.de/
ex: https://www.formel1.de/
ex: https://www.formel1.de/news/news/2022-04-18/kevin-magnussen-ueber-mick-schumacher-so-ist-die-zusammenarbeit-wirklich
![Screenshot 2022-04-19 at 14 14 42](https://user-images.githubusercontent.com/1289147/164001408-b393ec8e-ef4c-4e48-93f0-2bebe1270f39.png)
![Screenshot 2022-04-19 at 14 15 07](https://user-images.githubusercontent.com/1289147/164001418-a273b1fa-d237-495e-8806-e658c0c19b47.png)
![Screenshot 2022-04-19 at 14 15 36](https://user-images.githubusercontent.com/1289147/164001423-0713456f-2bc6-4b68-8502-837cfb795589.png)


