### PR TITLE
Refine behavior on Substack

### DIFF
--- a/shutup.css
+++ b/shutup.css
@@ -820,6 +820,9 @@ table.ttxt2 td.ctxt,
 /* Chess.com */
 #comments-component,
 
+/* Substack */
+.comments-section,
+
 /* Various shady sites */
 .content form ~ a#ci ~ div[id^=c0],
 .content form ~ a#ci ~ div[id^=c1],

--- a/shutup.css
+++ b/shutup.css
@@ -927,6 +927,10 @@ body > div#dimmers + .quote_container .comment
 /* GitHub - Pull Request comments */
 .repository-content .comment,
 
+/* Substack comments pages */
+div.comments-page div.comment-list,
+div.comments-page div.comment-list div.comment,
+
 /* WordPress admin panel comment view */
 #wpcom main.comments,
 #wpcom main.comments .comment-list,


### PR DESCRIPTION
- Hide the comment counts and comment composition text field near the bottom of posts.
- _Stop_ hiding the comments on dedicated comments pages.