### PR TITLE
Hide new cooking.nytimes section

### DIFF
--- a/shutup.css
+++ b/shutup.css
@@ -166,7 +166,7 @@ p.theme-comments,
 
 /* cooking.nytimes.com */
 #userNotesMount,
-#notes_section
+#notes_section,
 
 /* Wall Street Journal */
 #comments_sector,


### PR DESCRIPTION
Added missing comma to cooking.nytimes.com #notes_section