### PR TITLE
Hide some WordPress sidebar widgets

### DIFF
--- a/shutup.css
+++ b/shutup.css
@@ -33,6 +33,9 @@
  *
  */
 
+/* WordPress */
+.wp-block-latest-comments,
+
 /* YouTube */
 #watch-comment-panel,
 #watch-comments-core,
@@ -812,6 +815,7 @@ body [class*=commentaires i],
 .section-comment,
 .user_comment,
 .widget-comments,
+.widget_recent_comments,
 #article-comments,
 #articleComments,
 #blogComments,


### PR DESCRIPTION
- `.wp-block-latest-comments` example: https://statmodeling.stat.columbia.edu/2024/02/22/why-we-say-that-honesty-and-transparency-are-not-enough/
- `.widget_recent_comments` example: https://pedestrianobservations.com/2024/02/19/new-york-new-haven-trains-in-an-hour/