### PR TITLE
Hide comment-related UI on GitHub commit pages

### DIFF
--- a/shutup.css
+++ b/shutup.css
@@ -751,6 +751,9 @@ app-creator-detail-page app-post-detail-card div.card-footer,
 /* Ghost */
 div.gh-comments,
 
+/* GitHub commit pages */
+#all_commit_comments,
+
 /* Various shady sites */
 .content form ~ a#ci ~ div[id^=c0],
 .content form ~ a#ci ~ div[id^=c1],


### PR DESCRIPTION
Comments are already hidden, but the comment count and submission form are not.

Very recently relevant example: https://github.com/tukaani-project/xz/commit/6e636819e8f070330d835fce46289a3ff72a7b89