### PR TITLE
Improve handling of GitHub comments

### DIFF
--- a/shutup.css
+++ b/shutup.css
@@ -902,7 +902,7 @@ body > div#dimmers + .quote_container .comment
 
 
 /* GitHub - Pull Request comments */
-.repository-content .comment,
+.pull-request-tab-content .comment,
 
 /* Substack comments pages */
 div.comments-page div.comment-list,

--- a/shutup.css
+++ b/shutup.css
@@ -754,6 +754,7 @@ div.gh-comments,
 /* GitHub */
 .inline-comments,
 #all_commit_comments,
+.gist-content a[name="comments"] + div,
 
 /* Various shady sites */
 .content form ~ a#ci ~ div[id^=c0],

--- a/shutup.css
+++ b/shutup.css
@@ -751,6 +751,9 @@ app-creator-detail-page app-post-detail-card div.card-footer,
 /* Ghost */
 div.gh-comments,
 
+/* GitHub */
+.inline-comments,
+
 /* Various shady sites */
 .content form ~ a#ci ~ div[id^=c0],
 .content form ~ a#ci ~ div[id^=c1],
@@ -914,4 +917,12 @@ div.comments-page div.comment-list div.comment,
 #wpcom main.comments .comment-list .comment
 {
 	display: block !important;
+}
+
+
+
+/* GitHub pull request inline comments */
+.pull-request-tab-content .inline-comments
+{
+	display: table-row !important;
 }

--- a/shutup.css
+++ b/shutup.css
@@ -753,6 +753,7 @@ div.gh-comments,
 
 /* GitHub */
 .inline-comments,
+#all_commit_comments,
 
 /* Various shady sites */
 .content form ~ a#ci ~ div[id^=c0],


### PR DESCRIPTION
- Update the selector that keeps comments visible on pull request pages.  The old one is unreliable because sometimes the necessary ancestor is present and sometimes it isn't (?!?).
- Hide inline comments displayed in the middle of diffs, but exempt pull request pages.
- Hide the comment count and comment submission form at the bottom of commit pages.
- Hide comments on Gists.