### PR TITLE
Improve comment blocking on several websites

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The simplest way to use shutup.css on a conventional desktop or laptop computer 
 * [Shut Up for Edge][ext-edge]
 * [Shut Up for Opera][ext-opera]
 
-These extensions by [Ricky Romero][site-ricky] automatically update themselves with the latest shutup.css stylesheet, and allow you to toggle comment blocking on and off with a toolbar button.
+These extensions by [Ricky Romero][site-ricky] automatically include or retrieve the latest shutup.css stylesheet, and allow you to toggle comment blocking on and off with a toolbar button.
 
 Shut Up for Safari on macOS requires macOS Sierra or later.
 
@@ -84,7 +84,7 @@ This may affect some web applications in unexpected ways. I'm told it hides the 
 
 Stylesheets like shutup.css contain no executable code, so they cannot track or spy on you.
 
-The official browser extensions by Ricky Romero are designed to protect your privacy. None of these extensions track or spy on your browsing activity. They all have similar features, but differ in how they integrate with your browser. Most of these extensions have a built-in update mechanism for shutup.css. [Read the plain-English privacy policy here][ext-privacy] for info specific to your browser.
+The official browser extensions by Ricky Romero are designed to protect your privacy. None of these extensions track or spy on your browsing activity. They all have similar features, but differ in how they integrate with your browser. [Read the plain-English privacy policy here][ext-privacy] for info specific to your browser.
 
 ## Can I contribute to shutup.css?
 

--- a/shutup.css
+++ b/shutup.css
@@ -59,14 +59,26 @@ body [class*=disqus i],
 /* spot.im AKA OpenWeb */
 body [id*=spotim i],
 body [id*=spot-im i],
+body [id*=openweb i],
 body [class*=spotim i],
 body [class*=spot-im i],
+body [class*=openweb i],
 [data-spot-im-shadow-host],
+[data-spotim-module],
 
 /* Coral */
 div#coral_talk_stream,    /* v4 */
 div#coral_thread,         /* v5 */
 #coral-container,         /* as seen on WSJ */
+
+/* Viafoura */
+body [id*=viafoura i],
+body [class*=viafoura i],
+.vf-comments,
+
+/* Vuukle */
+body [id*=vuukle i],
+body [class*=vuukle i],
 
 /* Ain't It Cool News */
 .block-talkback_story,
@@ -124,6 +136,9 @@ div#shoutbox section.shoutbox,
 /* Yahoo News */
 .mwpphu-comments,
 .ugccmt-comments,
+
+/* Yahoo News (Japan) */
+#articleCommentModule,
 
 /* Coding Horror */
 #discourse-comments,
@@ -264,6 +279,15 @@ html#facebook [aria-label^="\41E \442 \432 \435 \442 "],                      /*
 .UFIComment,
 fb\:comments,
 div[data-testid^=UFI2CommentsList],
+
+/* x.com replies */
+[aria-label="Timeline: Conversation"] div:has(button[data-testid="tweetButtonInline"]) ~ div:has(article[data-testid="tweet"]),
+
+/* Mastodon replies */
+.status-reply.status--in-thread,
+
+/* Bluesky replies */
+.r-1jj8364 div:has([data-testid^="replyPromptBtn"]) ~ div:has([data-testid^="postThreadItem"]),
 
 /* LinkedIn */
 .comments-comment-item,
@@ -521,14 +545,16 @@ nav[aria-label="Hopin main menu"] ~ div.test-id-panel#side-panel,
 [data-test-tag="comment-row"],
 [data-tag="post-details"] ~ :last-child,
 
-/* Instagram */
+/* Instagram (Extremely obfuscated and fragile...) */
 ul._a9ym, /* Detail page, all comments except OP */
 article._ab6k._ab6m div._ab8w > div._ab8w > div._ab8w, /* Feed, all comments except OP */
 article._ab6k._ab6m div._ab8w > div._ab8w a div._aad6._aade, /* Feed, show comments link */
-
-/* Instagram (mobile site) */
-div.rBNOH.ybXk5, /* Detail page, all comments except OP */
-div.EtaWk > div > div:nth-child(2), /* Replies container */
+div.rBNOH.ybXk5, /* Mobile detail page, all comments except OP */
+div.EtaWk > div > div:nth-child(2), /* Mobile replies container */
+[id^="mount_"] .xw2csxc .x12nagc ~ div, /* Comment */
+[id^="mount_"] a[href$="/comments/"], /* Comments link */
+[id^="mount_"] .x1sxyh0:has(svg[aria-label="Comment"]), /* Comment icon, mobile */
+[id^="mount_"] .x1rg5ohu:has(svg[aria-label="Comment"]), /* Comment icon, desktop */
 
 /* Pixiv */
 div#root > div#gtm-var-theme-kind ~ div main > section > div > div >
@@ -726,7 +752,7 @@ table.ttxt2 td.ctxt,
 [data-testid="comments-cta"],
 
 /* formel1.de */
-.fa-comments,
+span.fa-comments,
 
 /* vnexpress.net */
 .count_cmt,
@@ -747,6 +773,10 @@ app-creator-detail-page app-post-detail-card div.card-footer,
 .insticator-unit,
 #insticator-commenting,
 .instiengage-comments,
+
+/* HoYoLAB */
+.mhy-article-page-reply,
+.mhy-article-card__data-item-clickable:has(.icon-stats_reply),
 
 /* Ghost */
 div.gh-comments,
@@ -775,6 +805,7 @@ div.gh-comments,
 #ws > #content > table#details ~ table,
 
 /* *** Generic *** */
+body [data-test-id*="comment" i],
 body [id*=commentaires i],
 body [class*=commentaires i],
 .all-comments,
@@ -794,6 +825,7 @@ body [class*=commentaires i],
 .commentBoxStyle,
 .commenting-wrapper,
 .commentlist,
+.commentsarea,
 .comments__container,
 .comments_area,
 .comments-area,


### PR DESCRIPTION
Notably: X, Mastodon, Bluesky, Pinterest, Instagram, and any sites using the Vuukle/SpotIM/OpenWeb/Viafoura comment platforms.

Also updated the README; most of the browser extensions no longer include a stylesheet update component due to Manifest v3 requirements around remotely hosted code.

ex: https://www.euronews.com/my-europe/2024/06/07/danish-prime-minister-frederiksen-assaulted-in-copenhagen
ex: https://nypost.com/2024/07/08/us-news/woman-accused-in-caught-on-camera-fatal-midtown-stabbing-laughs-in-court/
ex: https://www.cnn.com/travel/canada-dream-supersonic-bomber-avro-arrow/index.html
ex: https://www.miamiherald.com/news/state/florida/article289855604.html?tbref=hp
ex: https://www.hoyolab.com/article/30560878
ex: https://x.com/dril/status/1804929146000470164
ex: https://mastodon.social/@Chrishallbeck/112753613476768077
ex: https://bsky.app/profile/jonbois.bsky.social/post/3kwsoeh5zqi22
ex: https://www.formel1.de/news/grand-prix-berichte/2024-07-08/tut-total-weh-wie-george-russells-traum-vom-silverstone-sieg-geplatzt-ist
ex: https://www.instagram.com/rakuten/p/C87FsR-sNwD/
ex: https://news.yahoo.co.jp/articles/96287231c5f6f39f01c1dc2a55cbbbfc1cdef422
ex: https://www.pinterest.com/pin/39899146691931378/