### PR TITLE
Hide activity and comment button on Threads.net

### DIFF
--- a/shutup.css
+++ b/shutup.css
@@ -33,6 +33,10 @@
  *
  */
 
+/* Threads.net */
+head:has(> link[href="https://www.threads.net/"]) + body div:has(> [aria-label="Reply"]),
+head:has(> link[href="https://www.threads.net/"]) + body div:has(> div > div > div[data-pressable-container] svg[aria-label="View activity"]) ~ div,
+
 /* WordPress */
 .wp-block-latest-comments,
 


### PR DESCRIPTION
```head:has(> link[href="https://www.threads.net/"]) + body div:has(> [aria-label="Reply"])```
Removes the comment button from posts, like here:

<img width="610" alt="image" src="https://github.com/user-attachments/assets/8e464ffe-9acb-495f-bceb-d5afdf1cba29">


```head:has(> link[href="https://www.threads.net/"]) + body div:has(> div > div > div[data-pressable-container] svg[aria-label="View activity"]) ~ div,```
is a bit janky, but it should remove the replies to any thread you click into.

<img width="623" alt="image" src="https://github.com/user-attachments/assets/e61043cf-1254-40b0-bc08-012260c88d66">
