### PR TITLE
Block comments on The Athletic by NYTimes

### DIFF
--- a/shutup.css
+++ b/shutup.css
@@ -174,6 +174,9 @@ div[data-hook=comments_thread],
 .readerComments,
 .commentsModule,
 
+/* NY Times: The Athletic */
+.article-container div:has(option[value="my_comments"]),
+
 /* nytimes.com */
 span.postMetaHeaderCommentCount.commentCount,
 button.comments-button,


### PR DESCRIPTION
ex: https://www.nytimes.com/athletic/5898997/2024/11/04/jason-kelce-taylor-swift-fan-altercation-comments-espn/