### PR TITLE
Update shutup.css, adding classes for the UOL Brazilian portal.

### DIFF
--- a/shutup.css
+++ b/shutup.css
@@ -806,6 +806,9 @@ p[class^="TuoreimmatItem__CommentTypography"],
 .__widget_DiscussionButton,
 .discussion-container,
 
+/* uol.com.br */
+section.solar-comment,
+
 /* Various shady sites */
 .content form ~ a#ci ~ div[id^=c0],
 .content form ~ a#ci ~ div[id^=c1],


### PR DESCRIPTION
You can check the comments not being blocked at the bottom of https://www.uol.com.br/splash/noticias/2024/12/09/as-artimanhas-usadas-para-deixar-ator-identico-a-ayrton-senna.htm. I noticed that they introduced this comment section around 1 month ago. As with any portal, the comments section is a very toxic place. 

Screenshot: ![image](https://github.com/user-attachments/assets/53b0181c-825c-4296-9ba7-8a231156e287)
