### PR TITLE
Block comments on more sites - Redux

### DIFF
--- a/shutup.css
+++ b/shutup.css
@@ -834,6 +834,10 @@ p[class^="TuoreimmatItem__CommentTypography"],
 /* uol.com.br */
 section.solar-comment,
 
+/* gamer.nl */
+html[data-theme="gamernl"] div[data-testid="badge__root"]:has(svg), /* Comment badge */
+html[data-theme="gamernl"] article > div > div > div:has(div.flex.flex-wrap.gap-2.items-center.mb-2):has(h3.heading5), /* Comments section */
+
 /* Various shady sites */
 .content form ~ a#ci ~ div[id^=c0],
 .content form ~ a#ci ~ div[id^=c1],

--- a/shutup.css
+++ b/shutup.css
@@ -654,7 +654,7 @@ div.article-view__meta-right:has(a[class="article__comments-link article-view__c
 .article-view__comments-link-2.js-thread-link,
 
 /* golem.de */
-.share-item.comments
+.share-item.comments,
 
 /* giga.de */
 #comments + #weiterethemen,
@@ -952,9 +952,12 @@ body [class*=commentaires i],
 #reacties,
 #show-comments-container,
 #user_commeent_section,
-#user-comments {
+#user-comments
+{
 	display: none !important;
 }
+
+
 
 /* *** Exceptions *** */
 
@@ -979,15 +982,21 @@ pre span.comment,
 /* MediaWiki edit summaries (Wikipedia, etc.) */
 #pagehistory .comment,
 table.diff .comment,
-.mw-summary-preview .comment {
+.mw-summary-preview .comment
+{
 	display: initial !important;
 }
 
+
+
 /* Fimfiction */
 .group-page > .group > div[data-thread-id] .comment,
-body > div#dimmers + .quote_container .comment {
+body > div#dimmers + .quote_container .comment
+{
 	display: table !important;
 }
+
+
 
 /* GitHub comments in pull requests and discussions/issues */
 .pull-request-tab-content .comment,
@@ -1000,11 +1009,15 @@ div.comments-page div.comment-list div.comment,
 /* WordPress admin panel comment view */
 #wpcom main.comments,
 #wpcom main.comments .comment-list,
-#wpcom main.comments .comment-list .comment {
+#wpcom main.comments .comment-list .comment
+{
 	display: block !important;
 }
 
+
+
 /* GitHub pull request inline comments */
-.pull-request-tab-content .inline-comments {
+.pull-request-tab-content .inline-comments
+{
 	display: table-row !important;
 }


### PR DESCRIPTION
This is based on @stonerl's PR #204, but fixes a missing trailing comma in a selector and restores the original CSS formatting style.

Affected sites:
- golem.de
- computerbase.de
- phoronix.com

@stonerl This PR should preserve your commit in the repo history. Thanks for your contribution.