### PR TITLE
Block comments on vi.nl

### DIFF
--- a/shutup.css
+++ b/shutup.css
@@ -412,6 +412,9 @@ html[data-theme="gamernl"] article > div > div > div:has(div.flex.flex-wrap.gap-
 /* nu.nl */
 .comments-link-wrapper,
 
+/* vi.nl */
+a[class*="NewsHeader_comment-section"],
+[class*="CommentsThread"],
 
 /* .pl
  * --------------------------------------------------------- */


### PR DESCRIPTION
ex: https://www.vi.nl/nieuws/partycrasher-vin-cius-stelt-titelfeest-barcelona-minimaal-tot-cl-sico-uit